### PR TITLE
chore(TASK-964): inject widget for availability detail on order detail page

### DIFF
--- a/src/admin/widgets/order/availability-info.tsx
+++ b/src/admin/widgets/order/availability-info.tsx
@@ -1,0 +1,35 @@
+import { WidgetConfig, OrderDetailsWidgetProps } from "@medusajs/admin";
+import { Container, Heading } from "@medusajs/ui";
+import { EyeMini } from "@medusajs/icons";
+import { Link } from "react-router-dom";
+
+import { toLocaleDate } from "../../utils/date";
+import adminRoutes from "../../constants/adminRoutes";
+
+const AvailabilityDetailWidget = ({ order }: OrderDetailsWidgetProps) => {
+  const formattedDate = toLocaleDate(order.availability.date);
+  const detailPageURL = `${adminRoutes.availabilities}/${order.availability.id}`;
+
+  return (
+    <Container>
+      <Heading>Information de la disponibilité</Heading>
+
+      <div className="flex mt-6 text-sm justify-between">
+        <dl className="flex">
+          <dt>Date de disponibilité : </dt>
+          <dd className="text-gray-500">&nbsp;{formattedDate}</dd>
+        </dl>
+
+        <Link to={detailPageURL} className="flex hover:underline text-gray-600">
+          <EyeMini /> Voir
+        </Link>
+      </div>
+    </Container>
+  );
+};
+
+export const config: WidgetConfig = {
+  zone: "order.details.after",
+};
+
+export default AvailabilityDetailWidget;


### PR DESCRIPTION
Affiche les détails de la disponibilité définie sur une commande sur la page détail de commande.

## Demo

https://github.com/LAZONEDEV/medusa-product-availability-plugin/assets/51182814/e6814557-36be-4887-b4f9-a18a3e273e53
