### PR TITLE
chore(backend): ensure that quantity calculation is done in same transactions

### DIFF
--- a/src/services/cart.ts
+++ b/src/services/cart.ts
@@ -9,6 +9,7 @@ import { Availability } from "@/models/availability";
 import AvailabilityProductRepository from "@/repositories/product-availability";
 import { OperationResult } from "@/types/api";
 import { CartService as MedusaCartService, Order } from "@medusajs/medusa";
+import { EntityManager } from "typeorm";
 
 class CartService extends MedusaCartService {
   async setAvailability(
@@ -30,119 +31,126 @@ class CartService extends MedusaCartService {
     }
   }
 
-  async verifyIfMatchesAvailability(cartId: string) {
-    return this.atomicPhase_(async (entityManager) => {
-      try {
-        const availabilityProdRepo = entityManager.withRepository(
-          AvailabilityProductRepository,
+  private async handleAvailabilityMatchesVerification(
+    cartId: string,
+    entityManager: EntityManager,
+  ) {
+    try {
+      const availabilityProdRepo = entityManager.withRepository(
+        AvailabilityProductRepository,
+      );
+      const orderRepo = entityManager.getRepository(Order);
+
+      const cart = await this.retrieve(cartId, {
+        relations: [
+          "items.variant.product",
+          "availability.availabilityProducts.product",
+        ],
+      });
+
+      if (!cart.availability) {
+        throw new CartValidationError(
+          cartCompletionErrorsInfo.AVAILABILITY_NOT_SET_ON_CART!,
         );
-        const orderRepo = entityManager.getRepository(Order);
-
-        const cart = await this.retrieve(cartId, {
-          relations: [
-            "items.variant.product",
-            "availability.availabilityProducts.product",
-          ],
-        });
-
-        if (!cart.availability) {
-          throw new CartValidationError(
-            cartCompletionErrorsInfo.AVAILABILITY_NOT_SET_ON_CART!,
-          );
-        }
-
-        const availability: Availability = cart.availability;
-
-        if (availability.status === AvailabilityStatus.Inactive) {
-          throw new CartValidationError(
-            cartCompletionErrorsInfo.AVAILABILITY_INACTIVE!,
-          );
-        }
-
-        // checking expiration
-        if (new Date(availability.date) < new Date()) {
-          throw new CartValidationError(
-            cartCompletionErrorsInfo.AVAILABILITY_EXPIRED!,
-          );
-        }
-
-        // check availability for each product in the cart
-        for (const item of cart.items) {
-          const product = item.variant.product;
-
-          const productAvailability = availability.availabilityProducts.find(
-            (p) => p.product.id === product.id,
-          );
-
-          if (!productAvailability) {
-            const errorMessage =
-              ValidationErrorMessage.productNotAvailableOnTheAvailability(
-                product.title,
-              );
-
-            throw new CartValidationError(
-              {
-                code: CartValidationErrorCode.PRODUCT_NOT_AVAILABLE_ON_AVAILABILITY,
-                message: errorMessage,
-              },
-              { productTitle: product.title },
-            );
-          }
-
-          if (productAvailability.quantity === null) {
-            // null as quantity means infinite, then just continue
-            continue;
-          }
-
-          const placedOrder = await availabilityProdRepo.getPlacedOrderQuantity(
-            productAvailability.id,
-            orderRepo,
-          );
-
-          const availableQuantity = productAvailability.quantity - placedOrder;
-
-          if (availableQuantity === 0) {
-            const errorMessage =
-              ValidationErrorMessage.productNoLongerAvailableOnAvailability(
-                product.title,
-              );
-            throw new CartValidationError(
-              {
-                code: CartValidationErrorCode.PRODUCT_NO_LONGER_AVAILABLE_ON_AVAILABILITY,
-                message: errorMessage,
-              },
-              { productTitle: product.title },
-            );
-          }
-
-          if (availableQuantity < item.quantity) {
-            const errorMessage =
-              ValidationErrorMessage.availableQuantityExceededError(
-                product.title,
-                availableQuantity,
-              );
-
-            throw new CartValidationError(
-              {
-                code: CartValidationErrorCode.AVAILABLE_QUANTITY_EXCEEDED,
-                message: errorMessage,
-              },
-              {
-                availableQuantity,
-                productTitle: product.title,
-              },
-            );
-          }
-        }
-
-        return {
-          success: true,
-          cart,
-        };
-      } catch (error) {
-        throw error;
       }
-    });
+
+      const availability: Availability = cart.availability;
+
+      if (availability.status === AvailabilityStatus.Inactive) {
+        throw new CartValidationError(
+          cartCompletionErrorsInfo.AVAILABILITY_INACTIVE!,
+        );
+      }
+
+      // checking expiration
+      if (new Date(availability.date) < new Date()) {
+        throw new CartValidationError(
+          cartCompletionErrorsInfo.AVAILABILITY_EXPIRED!,
+        );
+      }
+
+      // check availability for each product in the cart
+      for (const item of cart.items) {
+        const product = item.variant.product;
+
+        const productAvailability = availability.availabilityProducts.find(
+          (p) => p.product.id === product.id,
+        );
+
+        if (!productAvailability) {
+          const errorMessage =
+            ValidationErrorMessage.productNotAvailableOnTheAvailability(
+              product.title,
+            );
+
+          throw new CartValidationError(
+            {
+              code: CartValidationErrorCode.PRODUCT_NOT_AVAILABLE_ON_AVAILABILITY,
+              message: errorMessage,
+            },
+            { productTitle: product.title },
+          );
+        }
+
+        if (productAvailability.quantity === null) {
+          // null as quantity means infinite, then just continue
+          continue;
+        }
+
+        const placedOrder = await availabilityProdRepo.getPlacedOrderQuantity(
+          productAvailability.id,
+          orderRepo,
+        );
+
+        const availableQuantity = productAvailability.quantity - placedOrder;
+
+        if (availableQuantity === 0) {
+          const errorMessage =
+            ValidationErrorMessage.productNoLongerAvailableOnAvailability(
+              product.title,
+            );
+          throw new CartValidationError(
+            {
+              code: CartValidationErrorCode.PRODUCT_NO_LONGER_AVAILABLE_ON_AVAILABILITY,
+              message: errorMessage,
+            },
+            { productTitle: product.title },
+          );
+        }
+
+        if (availableQuantity < item.quantity) {
+          const errorMessage =
+            ValidationErrorMessage.availableQuantityExceededError(
+              product.title,
+              availableQuantity,
+            );
+
+          throw new CartValidationError(
+            {
+              code: CartValidationErrorCode.AVAILABLE_QUANTITY_EXCEEDED,
+              message: errorMessage,
+            },
+            {
+              availableQuantity,
+              productTitle: product.title,
+            },
+          );
+        }
+      }
+
+      return {
+        success: true,
+        cart,
+      };
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async verifyIfMatchesAvailability(cartId: string) {
+    return this.atomicPhase_(async (entityManager) =>
+      this.handleAvailabilityMatchesVerification(cartId, entityManager),
+    );
   }
 }
 

--- a/src/strategies/cart-completion.ts
+++ b/src/strategies/cart-completion.ts
@@ -4,10 +4,61 @@ import CartService from "@/services/cart";
 import { CartCompletionResponse, IdempotencyKey } from "@medusajs/medusa";
 import CoreCartCompletionStrategy from "@medusajs/medusa/dist/strategies/cart-completion";
 import { RequestContext } from "@medusajs/medusa/dist/types/request";
+import { EntityManager } from "typeorm";
 
 class CartCompletionStrategy extends CoreCartCompletionStrategy {
   constructor() {
     super(arguments[0]);
+  }
+
+  private async handleComplete(
+    cartId: string,
+    ikey: IdempotencyKey,
+    context: RequestContext,
+    manager: EntityManager,
+  ): Promise<CartCompletionResponse> {
+    try {
+      const { cart } = await (this.cartService_ as CartService)
+        .withTransaction(manager)
+        .verifyIfMatchesAvailability(cartId);
+
+      // call default cart completion strategy
+      const { response_body, response_code } = await super
+        .withTransaction(manager)
+        .complete(cartId, ikey, context);
+
+      const orderIsCreated = (response_body.data as Order)?.object === "order";
+
+      if (orderIsCreated) {
+        const orderRepo = this.activeManager_.getRepository(Order);
+
+        const order = response_body.data as Order;
+        // set availability to order
+        await orderRepo.update(
+          { id: order.id },
+          {
+            availability: {
+              id: cart.availability.id,
+            },
+          },
+        );
+      }
+
+      return { response_body, response_code };
+    } catch (error) {
+      if (error instanceof CartValidationError) {
+        return {
+          response_body: {
+            message: error.message,
+            code: error.code,
+            payload: error.payload,
+          },
+          response_code: 422,
+        };
+      }
+
+      throw error;
+    }
   }
 
   async complete(
@@ -15,51 +66,9 @@ class CartCompletionStrategy extends CoreCartCompletionStrategy {
     ikey: IdempotencyKey,
     context: RequestContext,
   ): Promise<CartCompletionResponse> {
-    return this.atomicPhase_(async (manager) => {
-      try {
-        const { cart } = await (this.cartService_ as CartService)
-          .withTransaction(manager)
-          .verifyIfMatchesAvailability(cartId);
-
-        // call default cart completion strategy
-        const { response_body, response_code } = await super
-          .withTransaction(manager)
-          .complete(cartId, ikey, context);
-
-        const orderIsCreated =
-          (response_body.data as Order)?.object === "order";
-
-        if (orderIsCreated) {
-          const orderRepo = this.activeManager_.getRepository(Order);
-
-          const order = response_body.data as Order;
-          // set availability to order
-          await orderRepo.update(
-            { id: order.id },
-            {
-              availability: {
-                id: cart.availability.id,
-              },
-            },
-          );
-        }
-
-        return { response_body, response_code };
-      } catch (error) {
-        if (error instanceof CartValidationError) {
-          return {
-            response_body: {
-              message: error.message,
-              code: error.code,
-              payload: error.payload,
-            },
-            response_code: 422,
-          };
-        }
-
-        throw error;
-      }
-    });
+    return this.atomicPhase_(async (manager) =>
+      this.handleComplete(cartId, ikey, context, manager),
+    );
   }
 }
 


### PR DESCRIPTION
Cette PR assure que la vérification des quantités restantes pour commande est faite dans la même transaction que celle du contexte de la requête de finalisation de commande.
De ma compression `medusa` permet de transmettre des transactions créées en amont. Donc ce que je fais dans cette PR permet d'exploiter la même transaction. 