### PR TITLE
fix(backend): resolve timeout error by removing transaction usage temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medusa-customizable-product-availability",
-  "version": "0.0.3",
+  "version": "0.0.14",
   "description": "Plugin for product availability management",
   "license": "MIT",
   "keywords": [

--- a/src/strategies/cart-completion.ts
+++ b/src/strategies/cart-completion.ts
@@ -4,7 +4,6 @@ import CartService from "@/services/cart";
 import { CartCompletionResponse, IdempotencyKey } from "@medusajs/medusa";
 import CoreCartCompletionStrategy from "@medusajs/medusa/dist/strategies/cart-completion";
 import { RequestContext } from "@medusajs/medusa/dist/types/request";
-import { EntityManager } from "typeorm";
 
 class CartCompletionStrategy extends CoreCartCompletionStrategy {
   constructor() {
@@ -15,17 +14,18 @@ class CartCompletionStrategy extends CoreCartCompletionStrategy {
     cartId: string,
     ikey: IdempotencyKey,
     context: RequestContext,
-    manager: EntityManager,
   ): Promise<CartCompletionResponse> {
     try {
-      const { cart } = await (this.cartService_ as CartService)
-        .withTransaction(manager)
-        .verifyIfMatchesAvailability(cartId);
+      const { cart } = await (
+        this.cartService_ as CartService
+      ).verifyIfMatchesAvailability(cartId);
 
       // call default cart completion strategy
-      const { response_body, response_code } = await super
-        .withTransaction(manager)
-        .complete(cartId, ikey, context);
+      const { response_body, response_code } = await super.complete(
+        cartId,
+        ikey,
+        context,
+      );
 
       const orderIsCreated = (response_body.data as Order)?.object === "order";
 
@@ -66,9 +66,7 @@ class CartCompletionStrategy extends CoreCartCompletionStrategy {
     ikey: IdempotencyKey,
     context: RequestContext,
   ): Promise<CartCompletionResponse> {
-    return this.atomicPhase_(async (manager) =>
-      this.handleComplete(cartId, ikey, context, manager),
-    );
+    return this.handleComplete(cartId, ikey, context);
   }
 }
 


### PR DESCRIPTION
Previously, the process was incomplete due to memory leaks and
unresolved completion requests. This commit addresses these issues by
removing the usage of transactions in the completion process
temporarily. Transactions were initially added to prevent race conditions,
but their removal is necessary until a comprehensive understanding of
the underlying problem is achieved.